### PR TITLE
fix broken rollup sourcemaps

### DIFF
--- a/src/import-assert.ts
+++ b/src/import-assert.ts
@@ -107,12 +107,12 @@ export function importAssertionsPlugin(): Plugin {
           code = `export default ${data}`;
         }
 
-        /** Return the new data and map it back to the original source file */
-        return { code, mappings: id };
+        /** Return the new data */
+        return { code, map: {mappings: ""} };
       }
 
       /** If none of the above exists, just continue as normal */
-      return { code };
+      return { code, map: null };
     }
   }
 }


### PR DESCRIPTION
The existing code is incorrect (`mappings` doesn't exist on `TransformResult`); we need to actually generate source maps if we want to create them (the docs suggest using `magic-string` if you're interested in adding them: https://github.com/rollup/rollup/blob/master/docs/05-plugin-development.md#source-code-transformations). The current setup actually breaks source maps (https://github.com/maplibre/maplibre-gl-js/issues/1582), and leads to the following output from `rollup`:

```
(!) Broken sourcemap
https://rollupjs.org/guide/en/#warning-sourcemap-is-likely-to-be-incorrect
Plugins that transform code (such as "rollup-plugin-import-assert") should generate accompanying sourcemaps
```

According to the docs/the typings, if the code isn't transformed, `map: null` should be included. If you generate source map, you should include the whole `ExistingRawSourceMap`, and if it doesn't make sense to generate source maps, `map: {mappings: ''}` should be returned with the transformed code.